### PR TITLE
Code review cleanup for DotNetOpenAuth.AspNet

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth/AuthenticationOnlyCookieOAuthTokenManager.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth/AuthenticationOnlyCookieOAuthTokenManager.cs
@@ -86,7 +86,10 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <param name="requestToken">The request token.</param>
 		/// <param name="requestTokenSecret">The request token secret.</param>
 		public void StoreRequestToken(string requestToken, string requestTokenSecret) {
-			var cookie = new HttpCookie(TokenCookieKey);
+			var cookie = new HttpCookie(TokenCookieKey) {
+				HttpOnly = true
+			};
+
 			if (FormsAuthentication.RequireSSL) {
 				cookie.Secure = true;
 			}

--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth/LinkedInClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth/LinkedInClient.cs
@@ -89,7 +89,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			Justification = "We don't care if the request fails.")]
 		protected override AuthenticationResult VerifyAuthenticationCore(AuthorizedTokenResponse response) {
 			// See here for Field Selectors API http://developer.linkedin.com/docs/DOC-1014
-			const string ProfileRequestUrl = "http://api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,industry,summary)";
+			const string ProfileRequestUrl = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,industry,summary)";
 
 			string accessToken = response.AccessToken;
 
@@ -99,7 +99,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			try {
 				using (WebResponse profileResponse = request.GetResponse()) {
 					using (Stream responseStream = profileResponse.GetResponseStream()) {
-						XDocument document = XDocument.Load(responseStream);
+						XDocument document = LoadXDocumentFromStream(responseStream);
 						string userId = document.Root.Element("id").Value;
 
 						string firstName = document.Root.Element("first-name").Value;
@@ -117,7 +117,8 @@ namespace DotNetOpenAuth.AspNet.Clients {
 							isSuccessful: true, provider: this.ProviderName, providerUserId: userId, userName: userName, extraData: extraData);
 					}
 				}
-			} catch (Exception exception) {
+			}
+			catch (Exception exception) {
 				return new AuthenticationResult(exception);
 			}
 		}

--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth/OAuthClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth/OAuthClient.cs
@@ -8,7 +8,10 @@ namespace DotNetOpenAuth.AspNet.Clients {
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics.CodeAnalysis;
+	using System.IO;
 	using System.Web;
+	using System.Xml;
+	using System.Xml.Linq;
 	using DotNetOpenAuth.Messaging;
 	using DotNetOpenAuth.OAuth;
 	using DotNetOpenAuth.OAuth.ChannelElements;
@@ -152,6 +155,20 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		#endregion
 
 		#region Methods
+
+		/// <summary>
+		/// Helper method to load an XDocument from an input stream.
+		/// </summary>
+		/// <param name="stream">The input stream from which to load the document.</param>
+		/// <returns>The XML document.</returns>
+		internal static XDocument LoadXDocumentFromStream(Stream stream) {
+			const int MaxChars = 0x10000; // 64k
+
+			XmlReaderSettings settings = new XmlReaderSettings() {
+				MaxCharactersInDocument = MaxChars
+			};
+			return XDocument.Load(XmlReader.Create(stream, settings));
+		}
 
 		/// <summary>
 		/// Check if authentication succeeded after user is redirected back from the service provider.

--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth/TwitterClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth/TwitterClient.cs
@@ -92,7 +92,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			string userId = response.ExtraData["user_id"];
 			string userName = response.ExtraData["screen_name"];
 
-			var profileRequestUrl = new Uri("http://api.twitter.com/1/users/show.xml?user_id="
+			var profileRequestUrl = new Uri("https://api.twitter.com/1/users/show.xml?user_id="
 									   + MessagingUtilities.EscapeUriDataStringRfc3986(userId));
 			var profileEndpoint = new MessageReceivingEndpoint(profileRequestUrl, HttpDeliveryMethods.GetRequest);
 			HttpWebRequest request = this.WebWorker.PrepareAuthorizedRequest(profileEndpoint, accessToken);
@@ -102,14 +102,15 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			try {
 				using (WebResponse profileResponse = request.GetResponse()) {
 					using (Stream responseStream = profileResponse.GetResponseStream()) {
-						XDocument document = XDocument.Load(responseStream);
+						XDocument document = LoadXDocumentFromStream(responseStream);
 						extraData.AddDataIfNotEmpty(document, "name");
 						extraData.AddDataIfNotEmpty(document, "location");
 						extraData.AddDataIfNotEmpty(document, "description");
 						extraData.AddDataIfNotEmpty(document, "url");
 					}
 				}
-			} catch (Exception) {
+			}
+			catch (Exception) {
 				// At this point, the authentication is already successful.
 				// Here we are just trying to get additional data if we can.
 				// If it fails, no problem.

--- a/src/DotNetOpenAuth.AspNet/UriHelper.cs
+++ b/src/DotNetOpenAuth.AspNet/UriHelper.cs
@@ -21,7 +21,8 @@ namespace DotNetOpenAuth.AspNet {
 		/// The url.
 		/// </param>
 		/// <param name="parameterName">
-		/// The parameter name.
+		/// The parameter name. This value should not be provided by an end user; the caller should
+        /// ensure that this value comes only from a literal string.
 		/// </param>
 		/// <param name="parameterValue">
 		/// The parameter value.


### PR DESCRIPTION
- Clients should use HTTPS instead of HTTP whenever possible.
- MachineKeyUtil reliability tweaks.
- Improved anti-XSRF protection when running under subdomains.
- Other miscellaneous minor cleanup.
