### PR TITLE
Add support for Web API HttpRequestMessage to the OAuth2 ResourceServer

### DIFF
--- a/src/DotNetOpenAuth.Core/DotNetOpenAuth.Core.csproj
+++ b/src/DotNetOpenAuth.Core/DotNetOpenAuth.Core.csproj
@@ -171,6 +171,7 @@
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectRoot)tools\DotNetOpenAuth.targets" />

--- a/src/DotNetOpenAuth.OAuth2.ResourceServer/DotNetOpenAuth.OAuth2.ResourceServer.csproj
+++ b/src/DotNetOpenAuth.OAuth2.ResourceServer/DotNetOpenAuth.OAuth2.ResourceServer.csproj
@@ -50,6 +50,9 @@
       <LastGenOutput>ResourceServerStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectRoot)tools\DotNetOpenAuth.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />

--- a/src/DotNetOpenAuth.OAuth2.ResourceServer/OAuth2/ResourceServer.cs
+++ b/src/DotNetOpenAuth.OAuth2.ResourceServer/OAuth2/ResourceServer.cs
@@ -11,6 +11,7 @@ namespace DotNetOpenAuth.OAuth2 {
 	using System.Diagnostics.Contracts;
 	using System.Linq;
 	using System.Net;
+	using System.Net.Http;
 	using System.Security.Principal;
 	using System.ServiceModel.Channels;
 	using System.Text;
@@ -173,6 +174,24 @@ namespace DotNetOpenAuth.OAuth2 {
 			Requires.NotNull(requestUri, "requestUri");
 
 			return this.GetPrincipal(new HttpRequestInfo(request, requestUri), requiredScopes);
+		}
+
+		/// <summary>
+		/// Discovers what access the client should have considering the access token in the current request.
+		/// </summary>
+		/// <param name="request">HTTP details from an incoming Web API message.</param>
+		/// <param name="requiredScopes">The set of scopes required to approve this request.</param>
+		/// <returns>
+		/// The principal that contains the user and roles that the access token is authorized for.  Never <c>null</c>.
+		/// </returns>
+		/// <exception cref="ProtocolFaultResponseException">
+		/// Thrown when the client is not authorized.  This exception should be caught and the
+		/// <see cref="ProtocolFaultResponseException.ErrorResponseMessage"/> message should be returned to the client.
+		/// </exception>
+		public virtual IPrincipal GetPrincipal(HttpRequestMessage request, params string[] requiredScopes) {
+			Requires.NotNull(request, "request");
+
+			return this.GetPrincipal(new HttpRequestInfo(request), requiredScopes);
 		}
 	}
 }

--- a/src/DotNetOpenAuth.Test/DotNetOpenAuth.Test.csproj
+++ b/src/DotNetOpenAuth.Test/DotNetOpenAuth.Test.csproj
@@ -175,6 +175,7 @@
     <Reference Include="System.Data.DataSetExtensions">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Runtime.Serialization">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>

--- a/src/DotNetOpenAuth.Test/Messaging/HttpRequestInfoTests.cs
+++ b/src/DotNetOpenAuth.Test/Messaging/HttpRequestInfoTests.cs
@@ -6,7 +6,9 @@
 
 namespace DotNetOpenAuth.Test.Messaging {
 	using System;
+	using System.Collections.Generic;
 	using System.Collections.Specialized;
+	using System.Net.Http;
 	using System.Web;
 	using DotNetOpenAuth.Messaging;
 	using NUnit.Framework;
@@ -118,6 +120,25 @@ namespace DotNetOpenAuth.Test.Messaging {
 			Uri actual = new HttpRequestWrapper(req).GetPublicFacingUrl(serverVariables);
 			Uri expected = new Uri("http://somehost:79/a.aspx?a=b");
 			Assert.AreEqual(expected, actual);
+		}
+
+		/// <summary>
+		/// Verifies the instantiation of HttpRequestInfo with a HttpRequestMessage object.
+		/// </summary>
+		[Test]
+		public void CtorHttpRequestMessage() {
+			var requestUri = new Uri("http://somehost/somepath?a=b");
+			HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, requestUri);
+			req.Headers.Add("X-Custom-Header", "somevalue");
+			var formData = new List<KeyValuePair<string, string>>();
+			formData.Add(new KeyValuePair<string, string>("bodyvar", "bodyval"));
+			req.Content = new FormUrlEncodedContent(formData);
+			var info = new HttpRequestInfo(req);
+			Assert.AreEqual("POST", info.HttpMethod);
+			Assert.AreEqual(requestUri, info.Url);
+			Assert.AreEqual("b", info.QueryString["a"]);
+			Assert.AreEqual("somevalue", info.Headers["X-Custom-Header"]);
+			Assert.AreEqual("bodyval", info.Form["bodyvar"]);
 		}
 	}
 }


### PR DESCRIPTION
This patch adds support for parsing System.Net.HttpRequestMessage, as used by the new Web API, in the OAuth2 ResourceServer.

Please note the following:
- The patch adds a dependency to System.Net.Http
- The body of HttpRequestMessage is supposed to be read asynchronously. Since HttpRequestInfo does not have an interface for this there is a blocking call. I don't think this is a real issue since the other HTTP interfaces supported might also suffer from this.
- The patch adds the HttpRequestMessage support to the ResourceServer only, not the AuthorizationServer.

The reason for the last point is simply that I use MVC for the authorization server and Web Api for the resource side, so I have no personal need for it. Also I am only interested in the OAuth2 part. If there is any interest in this I think I could extend this patch, but it won't be very soon.
