### PR TITLE
Retrieve the Facebook User's email as well as base user data by adding scope.

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth2/FacebookClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth2/FacebookClient.cs
@@ -78,7 +78,9 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			builder.AppendQueryArgs(
 				new Dictionary<string, string> {
 					{ "client_id", this.appId },
-					{ "redirect_uri", returnUrl.AbsoluteUri }
+					{ "redirect_uri", returnUrl.AbsoluteUri },
+					{ "scope", "email" }
+					
 				});
 			return builder.Uri;
 		}
@@ -133,6 +135,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 					{ "redirect_uri", NormalizeHexEncoding(returnUrl.AbsoluteUri) },
 					{ "client_secret", this.appSecret },
 					{ "code", authorizationCode },
+					{ "scope", "email" }
 				});
 
 			using (WebClient client = new WebClient()) {


### PR DESCRIPTION
Please allow the FacebookClient.cs file to retrieve the user's email as well as the rest of their default user data. Most of the other clients already return an email address if available however the facebook client does not  and there is no way to customize the scope currently.
