### PR TITLE
Updating Microsoft OAuth endpoints

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth2/MicrosoftClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth2/MicrosoftClient.cs
@@ -20,12 +20,12 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <summary>
 		/// The authorization endpoint.
 		/// </summary>
-		private const string AuthorizationEndpoint = "https://oauth.live.com/authorize";
+		private const string AuthorizationEndpoint = "https://login.live.com/oauth20_authorize.srf";
 
 		/// <summary>
 		/// The token endpoint.
 		/// </summary>
-		private const string TokenEndpoint = "https://oauth.live.com/token";
+		private const string TokenEndpoint = "https://login.live.com/oauth20_token.srf";
 
 		/// <summary>
 		/// The _app id.


### PR DESCRIPTION
I have production issue with my website today related to Microsoft account integration. After some debugging I found that error 500 is coming from Microsoft. Researching on Live connect forum I found that endpoints for OAuth is changed in April and Microsoft recommend to use new one. Updating endpoints resolve issues on my website.

See more details here http://social.msdn.microsoft.com/Forums/en-US/messengerconnect/threads

"We would like to inform you of about the changes to the OAuth 2.0 SDK.  We have transitioned the OAuth endpoints to https://login.live.com. This change is to move our OAuth 2.0 authentication service to be on the same backend as our primary login infrastructure. It will give increased scalability and reliability to our OAuth interface and also add some security features like invalidating refresh tokens if the users are detected as compromised or has changed their password.   

The https://oauth.live.com endpoints will continue to function but with slightly increased latency so we recommend you begin using the new URL’s.

The new endpoints are:

```
authorization: https://login.live.com/oauth20_authorize.srf
token: https://login.live.com/oauth20_token.srf
desktop: https://login.live.com/oauth20_desktop.srf
```

The old end points are:

```
authorization: https://oauth.live.com/authorize     
token: https://oauth.live.com/token
desktop: https://oauth.live.com/desktop"
```
