### PR TITLE
Update Reporting.SendStatsAsync to add additional exception handling to prevent a possible crash

### DIFF
--- a/src/DotNetOpenAuth.Core/Reporting.cs
+++ b/src/DotNetOpenAuth.Core/Reporting.cs
@@ -519,8 +519,12 @@ namespace DotNetOpenAuth {
 					SendStats();
 				} catch (Exception ex) {
 					// Something bad and unexpected happened.  Just deactivate to avoid more trouble.
-					Logger.Library.Error("Error while trying to submit statistical report.", ex);
 					broken = true;
+					try {
+						Logger.Library.Error("Error while trying to submit statistical report.", ex);
+					} catch (Exception) {
+						//swallow exceptions to prevent a crash
+					}
 				}
 			});
 		}

--- a/src/DotNetOpenAuth.Core/Reporting.cs
+++ b/src/DotNetOpenAuth.Core/Reporting.cs
@@ -519,8 +519,8 @@ namespace DotNetOpenAuth {
 					SendStats();
 				} catch (Exception ex) {
 					// Something bad and unexpected happened.  Just deactivate to avoid more trouble.
-					broken = true;
 					try {
+						broken = true;
 						Logger.Library.Error("Error while trying to submit statistical report.", ex);
 					} catch (Exception) {
 						//swallow exceptions to prevent a crash


### PR DESCRIPTION
In the case that SendStatsAsync fails and then when attempting to log the failure throws an exception.  It will crash the process using DotNetOpenAuth.

(Update the change to not have all the whitespace issues.  Sorry about that github client was doing something insane)
