### PR TITLE
Upate DNOA to support Front-End-Https header as well as X-Forwarded-Proto

### DIFF
--- a/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
+++ b/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
@@ -395,7 +395,8 @@ namespace DotNetOpenAuth.Messaging {
 			// the public URL:
 			if (serverVariables["HTTP_HOST"] != null) {
 				ErrorUtilities.VerifySupported(request.Url.Scheme == Uri.UriSchemeHttps || request.Url.Scheme == Uri.UriSchemeHttp, "Only HTTP and HTTPS are supported protocols.");
-				string scheme = serverVariables["HTTP_X_FORWARDED_PROTO"] ?? request.Url.Scheme;
+				string scheme = serverVariables["HTTP_X_FORWARDED_PROTO"] ??
+				(String.Equals(serverVariables["HTTP_FRONT_END_HTTPS"], "on", StringComparison.OrdinalIgnoreCase) ? Uri.UriSchemeHttps : request.Url.Scheme); 
 				Uri hostAndPort = new Uri(scheme + Uri.SchemeDelimiter + serverVariables["HTTP_HOST"]);
 				UriBuilder publicRequestUri = new UriBuilder(request.Url);
 				publicRequestUri.Scheme = scheme;


### PR DESCRIPTION
Our load balancer system uses Front-End-Https as the header to determine whether a request was terminated with HTTPS.  This header as per http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_headers is at least partially a standard for some microsoft products (we're actually using a combination of squid and Akamai for our SSL termination).

We've got a work around in place in our client code, but I figured I'd let you decide if you want to include an alternate header in the HTTPS detection.

Thanks
