### PR TITLE
Update samples/OpenIdProviderMvc/Controllers/OpenIdController.cs

### DIFF
--- a/samples/OpenIdProviderMvc/Controllers/OpenIdController.cs
+++ b/samples/OpenIdProviderMvc/Controllers/OpenIdController.cs
@@ -267,8 +267,12 @@ namespace OpenIdProviderMvc.Controllers {
 			}
 
 			Uri userLocalIdentifier = Models.User.GetClaimedIdentifierForUser(User.Identity.Name);
-			return authReq.LocalIdentifier == userLocalIdentifier ||
-				authReq.LocalIdentifier == PpidGeneration.PpidIdentifierProvider.GetIdentifier(userLocalIdentifier, authReq.Realm);
+			
+			 return authReq.LocalIdentifier.ToString().ToLowerInvariant() == userLocalIdentifier.ToString().ToLowerInvariant() 
+                            			||
+                   		authReq.LocalIdentifier.ToString().ToLowerInvariant() == PpidGeneration.PpidIdentifierProvider
+                                                                            .GetIdentifier(userLocalIdentifier, authReq.Realm)
+                                                                            .ToString().ToLowerInvariant();
 		}
 	}
 }


### PR DESCRIPTION
Previous version did not work, if user had already authorized on provider, and use to authorizing on consumer ids with uppercase symbol, for example http://provider.com/user/AlGol 
