### PR TITLE
Avoid appending to redirect_uri, but rather use state parameter

### DIFF
--- a/src/DotNetOpenAuth.AspNet/AuthenticationResult.cs
+++ b/src/DotNetOpenAuth.AspNet/AuthenticationResult.cs
@@ -122,5 +122,10 @@ namespace DotNetOpenAuth.AspNet {
 		/// It is not guaranteed to be unique and certainly does not merit any trust in any suggested authenticity.
 		/// </remarks>
 		public string UserName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets additional state associated with the <see cref="AuthenticationResult"/>.
+        /// </summary>
+	    public StateDictionary State { get; set; }
 	}
 }

--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth/OAuthClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth/OAuthClient.cs
@@ -109,11 +109,17 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <param name="returnUrl">
 		/// The return url after users have completed authenticating against external website. 
 		/// </param>
-		public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl) {
+        /// <param name="state">
+        /// Additional state to pass on the callback url.
+        /// </param>
+        public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl, StateDictionary state)
+        {
 			Requires.NotNull(returnUrl, "returnUrl");
 			Requires.NotNull(context, "context");
+            Requires.NotNull(state, "state");
 
 			Uri callback = returnUrl.StripQueryArgumentsWithPrefix("oauth_");
+            callback = callback.AttachQueryStringParameter("state", state.ToEncodedString());
 			this.WebWorker.RequestAuthentication(callback);
 		}
 

--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth2/OAuth2Client.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth2/OAuth2Client.cs
@@ -63,12 +63,18 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <param name="returnUrl">
 		/// The return url after users have completed authenticating against external website. 
 		/// </param>
-		public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl) {
+        /// <param name="state">
+        /// Additional state to pass on the callback url.
+        /// </param>
+        public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl, StateDictionary state)
+        {
 			Requires.NotNull(context, "context");
 			Requires.NotNull(returnUrl, "returnUrl");
+            Requires.NotNull(state, "state");
 
-			string redirectUrl = this.GetServiceLoginUrl(returnUrl).AbsoluteUri;
-			context.Response.Redirect(redirectUrl, endResponse: true);
+			Uri redirectUri = this.GetServiceLoginUrl(returnUrl);
+            redirectUri = redirectUri.AttachQueryStringParameter("state", state.ToEncodedString());
+            context.Response.Redirect(redirectUri.AbsoluteUri, endResponse: true);
 		}
 
 		/// <summary>

--- a/src/DotNetOpenAuth.AspNet/Clients/OpenID/OpenIDClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OpenID/OpenIDClient.cs
@@ -87,9 +87,11 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// </param>
 		[SuppressMessage("Microsoft.Usage", "CA2234:PassSystemUriObjectsInsteadOfStrings",
 			Justification = "We don't have a Uri object handy.")]
-		public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl) {
+        public virtual void RequestAuthentication(HttpContextBase context, Uri returnUrl, StateDictionary state)
+        {
 			Requires.NotNull(returnUrl, "returnUrl");
-
+            Requires.NotNull(state, "state");
+            returnUrl = returnUrl.AttachQueryStringParameter("state", state.ToEncodedString());
 			var realm = new Realm(returnUrl.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
 			IAuthenticationRequest request = RelyingParty.CreateRequest(this.providerIdentifier, realm, returnUrl);
 

--- a/src/DotNetOpenAuth.AspNet/DotNetOpenAuth.AspNet.csproj
+++ b/src/DotNetOpenAuth.AspNet/DotNetOpenAuth.AspNet.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Clients\OpenID\OpenIdClient.cs" />
     <Compile Include="Clients\OpenID\YahooOpenIdClient.cs" />
     <Compile Include="MachineKeyUtil.cs" />
+    <Compile Include="StateDictionary.cs" />
     <Compile Include="UriHelper.cs" />
     <Compile Include="IOpenAuthDataProvider.cs" />
     <Compile Include="OpenAuthAuthenticationTicketHelper.cs" />

--- a/src/DotNetOpenAuth.AspNet/IAuthenticationClient.cs
+++ b/src/DotNetOpenAuth.AspNet/IAuthenticationClient.cs
@@ -17,16 +17,19 @@ namespace DotNetOpenAuth.AspNet {
 		/// </summary>
 		string ProviderName { get; }
 
-		/// <summary>
-		/// Attempts to authenticate users by forwarding them to an external website, and upon succcess or failure, redirect users back to the specified url.
-		/// </summary>
-		/// <param name="context">
-		/// The context of the current request. 
-		/// </param>
-		/// <param name="returnUrl">
-		/// The return url after users have completed authenticating against external website. 
-		/// </param>
-		void RequestAuthentication(HttpContextBase context, Uri returnUrl);
+	    /// <summary>
+	    /// Attempts to authenticate users by forwarding them to an external website, and upon succcess or failure, redirect users back to the specified url.
+	    /// </summary>
+	    /// <param name="context">
+	    /// The context of the current request. 
+	    /// </param>
+	    /// <param name="returnUrl">
+	    /// The return url after users have completed authenticating against external website. 
+	    /// </param>
+	    /// <param name="state">
+	    /// Additional state to pass on the callback url.
+	    /// </param>
+	    void RequestAuthentication(HttpContextBase context, Uri returnUrl, StateDictionary state);
 
 		/// <summary>
 		/// Check if authentication succeeded after user is redirected back from the service provider.

--- a/src/DotNetOpenAuth.AspNet/StateDictionary.cs
+++ b/src/DotNetOpenAuth.AspNet/StateDictionary.cs
@@ -1,0 +1,70 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="StateDictionary.cs" company="iPrinciples Ltd">
+//   Copyright (c) 2013 iPrinciples Ltd.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+namespace DotNetOpenAuth.AspNet
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Web;
+
+    /// <summary>
+    /// Defines a dictionary for storing state passed on a callback url.
+    /// </summary>
+    public class StateDictionary : Dictionary<string, string>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateDictionary"/> class.
+        /// </summary>
+        public StateDictionary()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateDictionary"/> class.
+        /// </summary>
+        /// <param name="dictionary">
+        /// An existing dictionary containing state.
+        /// </param>
+        public StateDictionary(IDictionary<string, string> dictionary)
+            : base(dictionary)
+        {
+        }
+
+        /// <summary>
+        /// Attempts to parse the specified <paramref name="value"/> into a <see cref="StateDictionary"/>.
+        /// </summary>
+        /// <param name="value">The string value to parse.</param>
+        /// <param name="state">The generated <see cref="StateDictionary"/>.</param>
+        /// <returns><c>true</c> if the specified <paramref name="value"/> was parsed, <c>false</c> otherwise.</returns>
+        public static bool TryParse(string value, out StateDictionary state)
+        {
+            state = null;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            try
+            {
+                state  = new StateDictionary(HttpUtility.UrlDecode(value).Split('&').Select(x => x.Split('=')).ToDictionary(x => x[0], x => x[1]));
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Converts the current <see cref="StateDictionary"/> into an url encoded string.
+        /// </summary>
+        /// <returns>The generated string value.</returns>
+        public string ToEncodedString()
+        {
+            return HttpUtility.UrlEncode(string.Join("&", this.Select(x => string.Format("{0}={1}", x.Key, x.Value))));
+        }
+    }
+}


### PR DESCRIPTION
Added support for passing additional state on the callback url e.g. a
return url. Modified the OpenAuthSecurityManager to delegate
responsibility to the IAuthenticationClients for passing the provider
name and session id on either the redirect url or login url (OAuth2
specifically has a state parameter for passing additional session info
on the login url, passing additional information on the callback url
isn't supported by googles implementation of OAuth2). Removed redundant
provider name and session id passed on the callback in
VerifyAuthentication.
