### PR TITLE
Fix to StandardWebRequestHandler Error Logging

### DIFF
--- a/src/DotNetOpenAuth.Core/Messaging/StandardWebRequestHandler.cs
+++ b/src/DotNetOpenAuth.Core/Messaging/StandardWebRequestHandler.cs
@@ -168,7 +168,7 @@ namespace DotNetOpenAuth.Messaging {
 					}
 				} else {
 					Logger.Http.ErrorFormat(
-						"{0} connecting to {0}",
+						"{0} connecting to {1}",
 						ex.Status,
 						request.RequestUri);
 				}


### PR DESCRIPTION
The handler is logging the status twice instead of the status and URI.
