### PR TITLE
Fix extra data for the Google OpenID client

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OpenID/GoogleOpenIdClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OpenID/GoogleOpenIdClient.cs
@@ -38,6 +38,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 				var extraData = new Dictionary<string, string>();
 				extraData.AddItemIfNotEmpty("email", fetchResponse.GetAttributeValue(WellKnownAttributes.Contact.Email));
 				extraData.AddItemIfNotEmpty("country", fetchResponse.GetAttributeValue(WellKnownAttributes.Contact.HomeAddress.Country));
+				extraData.AddItemIfNotEmpty("language", fetchResponse.GetAttributeValue(WellKnownAttributes.Preferences.Language));
 				extraData.AddItemIfNotEmpty("firstName", fetchResponse.GetAttributeValue(WellKnownAttributes.Name.First));
 				extraData.AddItemIfNotEmpty("lastName", fetchResponse.GetAttributeValue(WellKnownAttributes.Name.Last));
 
@@ -57,9 +58,10 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			// Attribute Exchange extensions
 			var fetchRequest = new FetchRequest();
 			fetchRequest.Attributes.AddRequired(WellKnownAttributes.Contact.Email);
-			fetchRequest.Attributes.AddOptional(WellKnownAttributes.Contact.HomeAddress.Country);
-			fetchRequest.Attributes.AddOptional(WellKnownAttributes.Name.First);
-			fetchRequest.Attributes.AddOptional(WellKnownAttributes.Name.Last);
+			fetchRequest.Attributes.AddRequired(WellKnownAttributes.Contact.HomeAddress.Country);
+			fetchRequest.Attributes.AddRequired(WellKnownAttributes.Preferences.Language);
+			fetchRequest.Attributes.AddRequired(WellKnownAttributes.Name.First);
+			fetchRequest.Attributes.AddRequired(WellKnownAttributes.Name.Last);
 
 			request.AddExtension(fetchRequest);
 		}


### PR DESCRIPTION
When you register the Google OpenID client (which is in many of the examples with OAuthWebSecurity), it doesn't currently return the users name.  This is because Google won't return anything marked as "optional".

There is also an additional "language" item available, so we should return it.

See https://developers.google.com/accounts/docs/OpenID

Note that the "country" item is indeed shown in the documentation, but Google is currently ignoring it.  I left it in there anyway in case they ever fix it to match their docs.
