### PR TITLE
Improve Microsoft Client

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth2/MicrosoftClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth2/MicrosoftClient.cs
@@ -38,21 +38,34 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// </summary>
 		private readonly string appSecret;
 
+		/// <summary>
+		/// The requested scopes.
+		/// </summary>
+		private readonly string[] requestedScopes;
+
 		#endregion
 
 		#region Constructors and Destructors
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="MicrosoftClient"/> class.
+		/// Requests a scope of "wl.signin" by default.
 		/// </summary>
-		/// <param name="appId">
-		/// The app id.
-		/// </param>
-		/// <param name="appSecret">
-		/// The app secret.
-		/// </param>
+		/// <param name="appId">The app id.</param>
+		/// <param name="appSecret">The app secret.</param>
 		public MicrosoftClient(string appId, string appSecret)
-			: this("microsoft", appId, appSecret) {
+			: this("microsoft", appId, appSecret, "wl.signin")
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MicrosoftClient"/> class.
+		/// </summary>
+		/// <param name="appId">The app id.</param>
+		/// <param name="appSecret">The app secret.</param>
+		/// <param name="requestedScopes">One or more requested scopes.</param>
+		public MicrosoftClient(string appId, string appSecret, params string[] requestedScopes)
+			: this("microsoft", appId, appSecret, requestedScopes) {
 		}
 
 		/// <summary>
@@ -61,13 +74,15 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <param name="providerName">The provider name.</param>
 		/// <param name="appId">The app id.</param>
 		/// <param name="appSecret">The app secret.</param>
-		protected MicrosoftClient(string providerName, string appId, string appSecret)
+		/// <param name="requestedScopes">One or more requested scopes.</param>
+		protected MicrosoftClient(string providerName, string appId, string appSecret, string[] requestedScopes)
 			: base(providerName) {
 			Requires.NotNullOrEmpty(appId, "appId");
 			Requires.NotNullOrEmpty(appSecret, "appSecret");
 
 			this.appId = appId;
 			this.appSecret = appSecret;
+			this.requestedScopes = requestedScopes;
 		}
 
 		#endregion
@@ -93,7 +108,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 			builder.AppendQueryArgs(
 				new Dictionary<string, string> {
 					{ "client_id", this.appId },
-					{ "scope", "wl.basic" },
+					{ "scope", string.Join(" ", this.requestedScopes) },
 					{ "response_type", "code" },
 					{ "redirect_uri", returnUrl.AbsoluteUri },
 				});


### PR DESCRIPTION
Allow the developer to specify different scopes.  Set the default scope to "wl.signin" instead of "wl.basic".  This provides a better out-of-the-box experience.

See  http://stackoverflow.com/q/15125410/634824
