### PR TITLE
 A possible fix for exception in ClaimsResponse.Culture, if Language + Country doesn't make a valid culture.

### DIFF
--- a/src/DotNetOpenAuth.OpenId/OpenId/Extensions/SimpleRegistration/ClaimsResponse.cs
+++ b/src/DotNetOpenAuth.OpenId/OpenId/Extensions/SimpleRegistration/ClaimsResponse.cs
@@ -203,7 +203,13 @@ namespace DotNetOpenAuth.OpenId.Extensions.SimpleRegistration {
 					if (!string.IsNullOrEmpty(this.Country)) {
 						cultureString += "-" + this.Country;
 					}
-					this.culture = CultureInfo.GetCultureInfo(cultureString);
+					//Language + Country not neccessarily make a valid culture identifier
+					try {
+						this.culture = CultureInfo.GetCultureInfo(cultureString);
+					}
+					catch(CultureNotFoundException) {
+						this.culture = CultureInfo.GetCultureInfo(this.Language);
+					}
 				}
 
 				return this.culture;


### PR DESCRIPTION
A possible fix for the exception in #260.

Just a simple try-catch. According to this comment at SO http://stackoverflow.com/a/12375100 using try-catch is the fastest is you don't expect a continuous stream of illegal combinations.
