### PR TITLE
Fixed error when building when property SignAssembly set to False

### DIFF
--- a/src/DotNetOpenAuth.Core/Properties/AssemblyInfo.cs
+++ b/src/DotNetOpenAuth.Core/Properties/AssemblyInfo.cs
@@ -62,6 +62,7 @@ using System.Web.UI;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 #else
 [assembly: InternalsVisibleTo("DotNetOpenAuth.Test")]
+[assembly: InternalsVisibleTo("DotNetOpenAuth.Core.UI")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.InfoCard")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.InfoCard.UI")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.OpenId")]
@@ -81,6 +82,7 @@ using System.Web.UI;
 [assembly: InternalsVisibleTo("DotNetOpenAuth.OAuth2.ClientAuthorization")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.OAuth2.ResourceServer")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.OAuth2.Client")]
+[assembly: InternalsVisibleTo("DotNetOpenAuth.OAuth2.Client.UI")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.AspNet.Test")]
 [assembly: InternalsVisibleTo("DotNetOpenAuth.AspNet")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
This is small fix that allow build solution without using any strong names.
