### PR TITLE
Restore constructor which was removed

### DIFF
--- a/src/DotNetOpenAuth.AspNet/OpenAuthSecurityManager.cs
+++ b/src/DotNetOpenAuth.AspNet/OpenAuthSecurityManager.cs
@@ -58,14 +58,14 @@ namespace DotNetOpenAuth.AspNet {
 
 		#region Constructors and Destructors
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OpenAuthSecurityManager"/> class.
-        /// </summary>
-        /// <param name="requestContext">
-        /// The request context. 
-        /// </param>
-        public OpenAuthSecurityManager(HttpContextBase requestContext)
-            : this(requestContext, provider: null, dataProvider: null) { }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OpenAuthSecurityManager"/> class.
+		/// </summary>
+		/// <param name="requestContext">
+		/// The request context. 
+		/// </param>
+		public OpenAuthSecurityManager(HttpContextBase requestContext)
+			: this(requestContext, provider: null, dataProvider: null) { }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="OpenAuthSecurityManager"/> class.

--- a/src/DotNetOpenAuth.AspNet/OpenAuthSecurityManager.cs
+++ b/src/DotNetOpenAuth.AspNet/OpenAuthSecurityManager.cs
@@ -58,6 +58,15 @@ namespace DotNetOpenAuth.AspNet {
 
 		#region Constructors and Destructors
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenAuthSecurityManager"/> class.
+        /// </summary>
+        /// <param name="requestContext">
+        /// The request context. 
+        /// </param>
+        public OpenAuthSecurityManager(HttpContextBase requestContext)
+            : this(requestContext, provider: null, dataProvider: null) { }
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="OpenAuthSecurityManager"/> class.
 		/// </summary>
@@ -72,9 +81,6 @@ namespace DotNetOpenAuth.AspNet {
 		/// </param>
 		public OpenAuthSecurityManager(
 			HttpContextBase requestContext, IAuthenticationClient provider, IOpenAuthDataProvider dataProvider) {
-			Requires.NotNull(requestContext, "requestContext");
-			Requires.NotNull(provider, "provider");
-			Requires.NotNull(dataProvider, "dataProvider");
 
 			this.requestContext = requestContext;
 			this.dataProvider = dataProvider;


### PR DESCRIPTION
Restore constructor which breaks OauthWebSecurity
This is to fix issue 251 on Github:
https://github.com/DotNetOpenAuth/DotNetOpenAuth/issues/251

This will re-break the following issue, which needs more thought to
correctly implement: 

http://stackoverflow.com/questions/12235395/openauth-requestauthentication-throws-null-ref-in-vs2012-web-forms-template/12240150#12240150
