### PR TITLE
Facebook Client should support scope parameter

### DIFF
--- a/src/DotNetOpenAuth.AspNet/Clients/OAuth2/FacebookClient.cs
+++ b/src/DotNetOpenAuth.AspNet/Clients/OAuth2/FacebookClient.cs
@@ -41,6 +41,11 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// </summary>
 		private readonly string appSecret;
 
+        /// <summary>
+        /// The scope.
+        /// </summary>
+        private readonly string scope;
+
 		#endregion
 
 		#region Constructors and Destructors
@@ -54,13 +59,14 @@ namespace DotNetOpenAuth.AspNet.Clients {
 		/// <param name="appSecret">
 		/// The app secret.
 		/// </param>
-		public FacebookClient(string appId, string appSecret)
+		public FacebookClient(string appId, string appSecret, string scope = "email")
 			: base("facebook") {
 			Requires.NotNullOrEmpty(appId, "appId");
 			Requires.NotNullOrEmpty(appSecret, "appSecret");
 
 			this.appId = appId;
 			this.appSecret = appSecret;
+            this.scope = scope;
 		}
 
 		#endregion
@@ -81,7 +87,7 @@ namespace DotNetOpenAuth.AspNet.Clients {
 				new Dictionary<string, string> {
 					{ "client_id", this.appId },
 					{ "redirect_uri", returnUrl.AbsoluteUri },
-					{ "scope", "email" },
+					{ "scope", this.scope },
 				});
 			return builder.Uri;
 		}


### PR DESCRIPTION
I'm trying to pass the scope parameter to the facebook client. I was having issues compiling for mono under .NET 4.0. So I'm hoping to get this pull request in and have a new version out that I can use in my project.
