### PR TITLE
Copies missing headers (namely Content-Type) over to HttpResponse to fix "application/json" being sent out as "text/html".

### DIFF
--- a/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
+++ b/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
@@ -461,11 +461,7 @@ namespace DotNetOpenAuth.Messaging {
 			var responseContext = context.Response;
 			responseContext.StatusCode = (int)response.StatusCode;
 			responseContext.StatusDescription = response.ReasonPhrase;
-			foreach (var header in response.Headers) {
-				foreach (var value in header.Value) {
-					responseContext.AddHeader(header.Key, value);
-				}
-			}
+			responseContext.CopyHeadersFrom(response);
 
 			if (response.Content != null) {
 				await response.Content.CopyToAsync(responseContext.OutputStream).ConfigureAwait(false);
@@ -1211,6 +1207,30 @@ namespace DotNetOpenAuth.Messaging {
 				} else {
 					if (!message.Headers.TryAddWithoutValidation(headerName, headerValues)) {
 						message.Content.Headers.TryAddWithoutValidation(headerName, headerValues);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Copies HTTP headers over to the <see cref="HttpResponse" /> from a <see cref="HttpResponseMessage"/>.
+		/// </summary>
+		/// <param name="response">The response to set headers on.</param>
+		/// <param name="message">The message with headers to clone.</param>
+		internal static void CopyHeadersFrom(this HttpResponseBase response, HttpResponseMessage message) {
+			Requires.NotNull(response, "response");
+			Requires.NotNull(message, "message");
+
+			foreach (var header in message.Headers) {
+				foreach (var value in header.Value) {
+					response.AddHeader(header.Key, value);
+				}
+			}
+
+			if (message.Content != null) {
+				foreach (var header in message.Content.Headers) {
+					foreach (var value in header.Value) {
+						response.AddHeader(header.Key, value);
 					}
 				}
 			}


### PR DESCRIPTION
The response from the auth provider for the token was received as 'text/html' instead on 'application/json' on the client. The result was that the following exception is thrown by the client: "Unexpected response Content-Type text/html".

The cause is that the message's 'Content-Type' header is never copied over from the response message to the HttpResponse being sent out.
