### PR TITLE
Copy extra data from access token to refresh token and allow its inspection during CreateAccessToken

### DIFF
--- a/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/ChannelElements/TokenCodeSerializationBindingElement.cs
+++ b/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/ChannelElements/TokenCodeSerializationBindingElement.cs
@@ -63,7 +63,13 @@ namespace DotNetOpenAuth.OAuth2.ChannelElements {
 			if (refreshTokenResponse != null && refreshTokenResponse.HasRefreshToken) {
 				var refreshTokenCarrier = (IAuthorizationCarryingRequest)message;
 				var refreshToken = new RefreshToken(refreshTokenCarrier.AuthorizationDescription);
-				var refreshTokenFormatter = RefreshToken.CreateFormatter(this.AuthorizationServer.CryptoKeyStore);
+                // Copy the extra data on the access token to the refresh token,
+                // so that it can be used during issuing of a replacement access token.
+			    var at = refreshTokenCarrier.AuthorizationDescription as AccessToken;
+			    if (at != null) {
+			        refreshToken.ExtraData.AddRange(at.ExtraData);
+			    }
+			    var refreshTokenFormatter = RefreshToken.CreateFormatter(this.AuthorizationServer.CryptoKeyStore);
 				refreshTokenResponse.RefreshToken = refreshTokenFormatter.Serialize(refreshToken);
 			}
 

--- a/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/Messages/AccessTokenRefreshRequestAS.cs
+++ b/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/Messages/AccessTokenRefreshRequestAS.cs
@@ -27,6 +27,14 @@ namespace DotNetOpenAuth.OAuth2.AuthServer.Messages {
 			: base(tokenEndpoint, version) {
 		}
 
+        public override IDictionary<string, string> ExtraData
+        {
+            get
+            {
+                return ((IRefreshTokenCarryingRequest)this).AuthorizationDescription.ExtraData;
+            }
+        }
+
 	#region IRefreshTokenCarryingRequest members
 
 		/// <summary>

--- a/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/Messages/AccessTokenRefreshRequestAS.cs
+++ b/src/DotNetOpenAuth.OAuth2.AuthorizationServer/OAuth2/Messages/AccessTokenRefreshRequestAS.cs
@@ -31,7 +31,11 @@ namespace DotNetOpenAuth.OAuth2.AuthServer.Messages {
         {
             get
             {
-                return ((IRefreshTokenCarryingRequest)this).AuthorizationDescription.ExtraData;
+                // avoid returning null here.
+                var refreshToken = ((IRefreshTokenCarryingRequest) this).AuthorizationDescription;
+                return refreshToken == null
+                    ? base.ExtraData
+                    : refreshToken.ExtraData;
             }
         }
 

--- a/src/DotNetOpenAuth.OAuth2/OAuth2/Messages/MessageBase.cs
+++ b/src/DotNetOpenAuth.OAuth2/OAuth2/Messages/MessageBase.cs
@@ -98,7 +98,7 @@ namespace DotNetOpenAuth.OAuth2.Messages {
 		/// <remarks>
 		/// Implementations of this interface should ensure that this property never returns null.
 		/// </remarks>
-		public IDictionary<string, string> ExtraData {
+		public virtual IDictionary<string, string> ExtraData {
 			get { return this.extraData; }
 		}
 


### PR DESCRIPTION
To allow implementations which include extra data in the access token to
continue to use that extra data when issuing an access token based from
a refresh token.
