### PR TITLE
Fix System.Web.Mvc reference

### DIFF
--- a/samples/OAuth2ProtectedWebApi/OAuth2ProtectedWebApi.csproj
+++ b/samples/OAuth2ProtectedWebApi/OAuth2ProtectedWebApi.csproj
@@ -93,6 +93,7 @@
     <Reference Include="System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\src\packages\Microsoft.AspNet.Mvc.5.0.0\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Set System.Web.Mvc reference CopyLocal to true in OAuth2ProtectedWebApi.csproj.
Since a recent security update, the project will fail at runtime without this.
References: 
http://blogs.msdn.com/b/webdev/archive/2014/10/16/microsoft-asp-net-mvc-security-update-broke-my-build.aspx
http://stackoverflow.com/questions/26406804/after-windows-update-the-type-or-namespace-name-html-does-not-exist-in-the-na
