### PR TITLE
Fix to an incorrect call to IAuthorizationServerHost.GetClient

### DIFF
--- a/src/DotNetOpenAuth.Core/Messaging/Channel.cs
+++ b/src/DotNetOpenAuth.Core/Messaging/Channel.cs
@@ -407,7 +407,11 @@ namespace DotNetOpenAuth.Messaging {
 				var directRequest = requestMessage as IHttpDirectRequest;
 				if (directRequest != null) {
 					foreach (var header in httpRequest.Headers) {
-						directRequest.Headers.Add(header.Key, header.Value);
+						try {
+							directRequest.Headers.Add(header.Key, header.Value);
+						} catch (FormatException) {
+							ErrorUtilities.ThrowProtocol(MessagingStrings.UnexpectedMessagePartValue, header.Key, header.Value);
+						}
 					}
 				}
 

--- a/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
+++ b/src/DotNetOpenAuth.Core/Messaging/MessagingUtilities.cs
@@ -459,6 +459,11 @@ namespace DotNetOpenAuth.Messaging {
 			}
 
 			if (response.Content != null) {
+				foreach (var header in response.Content.Headers) {
+					foreach (var value in header.Value) {
+						responseContext.AddHeader(header.Key, value);
+					}
+				}
 				await response.Content.CopyToAsync(responseContext.OutputStream).ConfigureAwait(false);
 			}
 		}


### PR DESCRIPTION
The two calls to IAuthorizationServerHost.GetClient had mutually exclusive requirements:
1) Throw an exception if the Client is not found, do not return null
2) Return null if the Client is not found, do not throw an Exception

The problem prevented an OAuth2 Authorisation Server implementation from correctly handling an invalid ClientID - either the Authorize request would fail with a ProtocolException, or the Token request would fail with an ArgumentException.

This changes (2) to match the pattern of (1), which is also how the interface is documented.